### PR TITLE
Wait for idle network before starting test

### DIFF
--- a/modules/browsers/browser-interface.ts
+++ b/modules/browsers/browser-interface.ts
@@ -1,3 +1,6 @@
+import { WaitForOptions } from 'puppeteer';
+
+
 /**
  * Responsible for the low-level control of a browser
  */
@@ -7,7 +10,7 @@ export interface IBrowser {
     // control
     start(): Promise<void>,
     stop(): Promise<void>,
-    navigateTo(url: string): Promise<void>,
+    navigateTo(url: string, options?: WaitForOptions & { referer?: string; referrerPolicy?: string; }): Promise<void>,
     setViewport(options: { width: number, height: number }): Promise<void>,
 
     // commands

--- a/modules/browsers/chromium.ts
+++ b/modules/browsers/chromium.ts
@@ -1,6 +1,7 @@
 import puppeteer, { Page } from 'puppeteer';
 import type { IBrowser } from './browser-interface';
 import { ChildLogger, logger } from '../../src/logging/logger';
+import { WaitForOptions } from 'puppeteer';
 const delay = require('../delay/delay');
 
 const DEFAULT_OPTIONS = { name: 'chromium', headless: true };
@@ -86,8 +87,8 @@ export default class Chromium implements IBrowser {
         await Promise.all(pages.map(page => page.close()));
     }
 
-    async navigateTo(url: string) {
-        await (await this.getPage()).goto(url);
+    async navigateTo(url: string, options?: WaitForOptions & { referer?: string; referrerPolicy?: string; }) {
+        await (await this.getPage()).goto(url, options);
     }
 
     async setViewport(options: { width: number, height: number }) {

--- a/src/testrunner/testrunner.ts
+++ b/src/testrunner/testrunner.ts
@@ -344,6 +344,7 @@ export default class Testrunner extends EventEmitter {
 
     private async _runSuite(suite: Suite) {
         this._log.verbose(`running suite: ${suite.name || DEFAULT_SUITE_NAME}`);
+        this._log.info('Suite waitUntil: ' + suite.waitUntil);
 
         for (const test of suite.tests) {
             if (this._isAborting) {
@@ -460,7 +461,7 @@ export default class Testrunner extends EventEmitter {
 
         let testStartTime = 0;
 
-        await this._currentBrowser.navigateTo(suite.appUrl);
+        await this._currentBrowser.navigateTo(suite.appUrl, { waitUntil: suite.waitUntil ?? 'load' });
 
         if (suite.beforeFirstCommand) {
             await suite.beforeFirstCommand(this.directAPI);

--- a/types.d.ts
+++ b/types.d.ts
@@ -2,6 +2,7 @@ import type { ImageDiffOptions } from './modules/buffer-image-diff/image-diff';
 import type { IBrowser } from './modules/browsers/browser-interface';
 import type Testrunner from './src/testrunner';
 import { TEST_STATE } from './constants';
+import type { PuppeteerLifeCycleEvent } from 'puppeteer';
 
 type LogLevel = 'verbose' | 'debug' | 'info' | 'warn' | 'error';
 
@@ -94,6 +95,7 @@ interface Test {
 interface Suite {
     name: string
     appUrl: string
+    waitUntil?: PuppeteerLifeCycleEvent
     /** relative/absolute paths and/or globs */
     testFiles?: string[]
     tests?: Test[]


### PR DESCRIPTION
Added wait option before starting a test. this can be configured in a Suite. This will stabilize tests which start with redirects.